### PR TITLE
change update interval to be uniform across tests and factory

### DIFF
--- a/pkg/interfaces/contracts/pool-quantamm/IQuantAMMWeightedPool.sol
+++ b/pkg/interfaces/contracts/pool-quantamm/IQuantAMMWeightedPool.sol
@@ -60,7 +60,7 @@ interface IQuantAMMWeightedPool {
         uint64 epsilonMax;
         uint64 absoluteWeightGuardRail;
         uint256 maxTradeSizeRatio;
-        uint64 updateInterval;
+        uint40 updateInterval;
     }
 
     ///@notice the time variables used for interpolation
@@ -98,7 +98,7 @@ interface IQuantAMMWeightedPool {
         IERC20[] assets;
         IUpdateRule rule;
         address[][] oracles;
-        uint16 updateInterval;
+        uint40 updateInterval;
         uint64[] lambda;
         uint64 epsilonMax;
         uint64 absoluteWeightGuardRail;

--- a/pkg/pool-quantamm/contracts/QuantAMMWeightedPool.sol
+++ b/pkg/pool-quantamm/contracts/QuantAMMWeightedPool.sol
@@ -170,7 +170,7 @@ contract QuantAMMWeightedPool is
     uint256 internal maxTradeSizeRatio;
 
     ///@dev Minimum amount of seconds between two updates
-    uint64 public updateInterval;
+    uint40 public updateInterval;
 
     ///@dev the maximum amount of time that an oracle an be stale.
     uint oracleStalenessThreshold;

--- a/pkg/pool-quantamm/contracts/mock/MockPool.sol
+++ b/pkg/pool-quantamm/contracts/mock/MockPool.sol
@@ -5,7 +5,7 @@ import "@balancer-labs/v3-interfaces/contracts/pool-quantamm/IUpdateRule.sol";
 import "../rules/UpdateRule.sol";
 
 contract MockPool {
-    uint16 public  immutable updateInterval;
+    uint40 public  immutable updateInterval;
 
     int256 public lambda;
 
@@ -25,7 +25,7 @@ contract MockPool {
 
     uint256 public afterTokenTransferID;
 
-    constructor(uint16 _updateInterval, int256 _lambda, address _updateWeightRunner) {
+    constructor(uint40 _updateInterval, int256 _lambda, address _updateWeightRunner) {
         updateInterval = _updateInterval;
         lambda = _lambda;
         epsilonMax = 1 * 1e18; // PRBMathSD69x18 1
@@ -63,7 +63,7 @@ contract MockPool {
         IQuantAMMWeightedPool.PoolSettings memory _poolSettings;
         _poolSettings.rule = _rule;
         _poolSettings.oracles = _poolOracles;
-        _poolSettings.updateInterval = uint16(_updateInterval);
+        _poolSettings.updateInterval = uint40(_updateInterval);
         _poolSettings.lambda = _lambda;
         _poolSettings.epsilonMax = _epsilonMax;
         _poolSettings.absoluteWeightGuardRail = _absoluteWeightGuardRail;

--- a/pkg/pool-quantamm/contracts/mock/MockQuantAMMBasePool.sol
+++ b/pkg/pool-quantamm/contracts/mock/MockQuantAMMBasePool.sol
@@ -33,7 +33,7 @@ import "@balancer-labs/v3-interfaces/contracts/pool-quantamm/IUpdateRule.sol";
 import "../UpdateWeightRunner.sol";
 
 contract MockQuantAMMBasePool is IQuantAMMWeightedPool, IBasePool {
-    constructor(uint16 _updateInterval, address _updateWeightRunner) {
+    constructor(uint40 _updateInterval, address _updateWeightRunner) {
         updateInterval = _updateInterval;
         lambda = new uint64[](0);
         epsilonMax = 1 * 1e18; // PRBMathSD69x18 1

--- a/pkg/pool-quantamm/test/foundry/MultiBlockMEVFuzzer.t.sol
+++ b/pkg/pool-quantamm/test/foundry/MultiBlockMEVFuzzer.t.sol
@@ -118,7 +118,7 @@ contract MultiBlockMEVFuzzer is QuantAMMWeightedPoolContractsDeployer, BaseVault
 
     // constants
     uint64 public constant _MAX_SWAP_FEE_PERCENTAGE = 10e16;
-    uint16 private constant _UPDATE_INTERVAL = 60; // 60 seconds
+    uint40 private constant _UPDATE_INTERVAL = 60; // 60 seconds
     uint64 private constant _LAMBDA = 0.2e18; // 20% lambda
     int256 private constant _KAPPA = 0.2e18; // 20% kappa
     uint64 private constant _MAX_TRADE_SIZE_RATIO = 0.01e18; // 1% max trade size ratio

--- a/pkg/pool-quantamm/test/foundry/QuantAMMWeightedPoolGenericFuzzer.t.sol
+++ b/pkg/pool-quantamm/test/foundry/QuantAMMWeightedPoolGenericFuzzer.t.sol
@@ -52,7 +52,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
     int256 private constant _MIN_WEIGHT = int256(uint256(_ABSOLUTE_WEIGHT_GUARD_RAIL)); // 0.01e18
     int256 private constant _MAX_WEIGHT =
         1e18 - (int256(_NUM_TOKENS) - 1) * int256(uint256(_ABSOLUTE_WEIGHT_GUARD_RAIL)); // 1e18- (8-1) * 0.01e18 = 0.93e18
-    uint16 private constant _UPDATE_INTERVAL = 60; // 60 seconds
+    uint40 private constant _UPDATE_INTERVAL = 60; // 60 seconds
 
     uint64 private constant _LAMBDA = 0.2e18; // 20% lambda
     int256 private constant _KAPPA = 0.2e18; // 20% kappa
@@ -95,7 +95,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         uint64 epsilonMax;
         uint64 absoluteWeightGuardRail;
         uint64 maxTradeSizeRatio;
-        uint16 updateInterval;
+        uint40 updateInterval;
     }
 
     struct RuleFuzzParams {
@@ -1131,7 +1131,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         params.poolParams.maxSwapfee = _MAX_SWAP_FEE_PERCENTAGE;
         params.poolParams.absoluteWeightGuardRail = _ABSOLUTE_WEIGHT_GUARD_RAIL;
         params.poolParams.maxTradeSizeRatio = _MAX_TRADE_SIZE_RATIO;
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);
@@ -1160,7 +1160,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         params.poolParams.maxSwapfee = _MAX_SWAP_FEE_PERCENTAGE;
         params.poolParams.absoluteWeightGuardRail = _ABSOLUTE_WEIGHT_GUARD_RAIL;
         params.poolParams.maxTradeSizeRatio = _MAX_TRADE_SIZE_RATIO;
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);
@@ -1357,7 +1357,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         params.poolParams.maxSwapfee = _MAX_SWAP_FEE_PERCENTAGE;
         params.poolParams.absoluteWeightGuardRail = _ABSOLUTE_WEIGHT_GUARD_RAIL;
         params.poolParams.maxTradeSizeRatio = _MAX_TRADE_SIZE_RATIO;
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);
@@ -1385,7 +1385,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         params.poolParams.maxSwapfee = _MAX_SWAP_FEE_PERCENTAGE;
         params.poolParams.absoluteWeightGuardRail = _ABSOLUTE_WEIGHT_GUARD_RAIL;
         params.poolParams.maxTradeSizeRatio = _MAX_TRADE_SIZE_RATIO;
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);
@@ -1595,7 +1595,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         ruleParams.kappa = int256(bound(ruleParams.kappa, 0.01e18, 1e18));
         params.ruleParams = ruleParams;
         // fuzz update interval
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);
@@ -1711,7 +1711,7 @@ contract QuantAMMWeightedPoolGenericFuzzer is QuantAMMWeightedPoolContractsDeplo
         ruleParams.kappa = int256(bound(ruleParams.kappa, 0.01e18, 1e18));
         params.ruleParams = ruleParams;
         // fuzz update interval
-        params.poolParams.updateInterval = uint16(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
+        params.poolParams.updateInterval = uint40(bound(params.poolParams.updateInterval, 1, 7 * 86400)); // 7 days
 
         // fuzz the interpolation time
         params.interpolationTime = bound(params.interpolationTime, 1, params.poolParams.updateInterval);

--- a/pkg/pool-quantamm/test/foundry/UpdateWeightRunner.t.sol
+++ b/pkg/pool-quantamm/test/foundry/UpdateWeightRunner.t.sol
@@ -27,7 +27,7 @@ contract UpdateWeightRunnerTest is Test, QuantAMMTestUtils {
     uint256 constant FIXED_VALUE_2 = 1001;
     uint256 constant FIXED_VALUE_3 = 1002;
     uint256 constant DELAY = 3600;
-    uint16 constant UPDATE_INTERVAL = 1800;
+    uint40 constant UPDATE_INTERVAL = 1800;
     // Deploy UpdateWeightRunner contract before each test
     function setUp() public {
         (address ownerLocal, address addr1Local, address addr2Local) = (vm.addr(1), vm.addr(2), vm.addr(3));


### PR DESCRIPTION
Original definition in the pool is uint64. However the params struct in the factory was still set to the old uint16. This is fine for the current code base because everything is limited by uint16 max. Aligning the definition to uint40 the same as the update weight runner record for update interval means we expand the max update interval allowed while avoiding any silent cast issues